### PR TITLE
refactor: replace chained startswith calls with tuple constant PREFIXES

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ import shutil
 from datetime import datetime
 import urllib.parse
 
+PREFIXES = ('vless://', 'ss://', 'trojan://', 'tuic://')
 
 def get_v2ray_links(url):
     response = requests.get(url)
@@ -21,9 +22,10 @@ def get_v2ray_links(url):
         all_tags = divs + spans + codes + divs2 + span + main
 
         v2ray_configs = []
+
         for tag in all_tags:
             text = tag.get_text()
-            if text.startswith('vless://') or text.startswith('ss://') or text.startswith('trojan://') or text.startswith('tuic://'):
+            if text.startswith(PREFIXES):
                 v2ray_configs.append(text)
 
         return v2ray_configs


### PR DESCRIPTION
Wow, this is a cool repo! I made a small cleanup in `get_v2ray_links` in `main.py`: replaced chained `startswith` calls with a single tuple constant `PREFIXES`. No behavior change, output is identical. Hope this helps!